### PR TITLE
Add root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# TensorFlow Lite example snaps
+
+This repository contains a number of example snaps to show how to run machine learning workloads inside a snap package.
+
+## [Image Labelling](image-labelling)
+
+A bare bones Python script which takes an image file as input and prints out labels for it to the console.
+If you are new to snapping software, this is a good place to start.
+This example is accompanied by our blog post which you can read [here](https://ubuntu.com/blog/ai-inference-on-edge-with-tensorflow-lite).
+
+## [Upstream Examples](upstream-examples)
+
+A snap bundling the [TensorFlow Lite examples](https://www.tensorflow.org/lite/examples) for the Raspberry Pi.
+
+## [Ubuntu Frame](ubuntu-frame)
+
+A slightly more advanced example showing how a production machine learning workload can run on Ubuntu Core with Ubuntu Frame.


### PR DESCRIPTION
This repo does not currently have a readme in its root, as it got moved into the upstream examples directory. This PR adds a new readme with a short outline of what can be found in the three example subdirectories.