### PR TITLE
Use snapcraft-preload to redirect shm access

### DIFF
--- a/ubuntu-frame/snap/snapcraft.yaml
+++ b/ubuntu-frame/snap/snapcraft.yaml
@@ -24,6 +24,16 @@ package-repositories:
     key-id: 35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3
 
 parts:
+  snapcraft-preload:
+    source: https://github.com/sergiusens/snapcraft-preload.git
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr -DLIBPATH=/lib
+    override-build: |
+      craftctl default
+      mkdir -p $SNAPCRAFT_PART_INSTALL/lib
+      cp libsnapcraft-preload.so $SNAPCRAFT_PART_INSTALL/lib/libsnapcraft-preload.so
+
   local:
     plugin: nil
     source: snap/local
@@ -117,10 +127,11 @@ apps:
     install-mode: disable
     environment:
       DATA_DIR: $SNAP
+      SNAPCRAFT_PRELOAD_REDIRECT_ONLY_SHM: 1
     plugs:
       - home
       - camera
       - network-bind
       - raw-usb
     command-chain: [bin/daemon-wrapper.sh]
-    command: bin/python3 $SNAP/camera_detect_stream.py
+    command: usr/bin/snapcraft-preload $SNAP/bin/python3 $SNAP/camera_detect_stream.py

--- a/ubuntu-frame/snap/snapcraft.yaml
+++ b/ubuntu-frame/snap/snapcraft.yaml
@@ -1,10 +1,13 @@
-name: tf-custom-examples
-summary: TensorFlow Lite examples for Ubuntu Core
-description: This snap provides a a couple of apps to showcase the use of TensorFlow Lite on Ubuntu Core.
-version: 0.0.2
+name: tf-ubuntu-frame-example
+summary: TensorFlow Lite examples for Ubuntu Core with Ubuntu Frame
+description: |
+  This snap provides a a couple of apps to showcase the use of TensorFlow Lite on Ubuntu Core.
+  Ubuntu Frame can be used to show the output on a local display, or the result can be streamed via a network connection.
+  The snap includes the necessary libraries to use a Coral Edge TPU.
+version: 0.0.3
 
 confinement: strict
-grade: devel
+grade: stable
 license: Apache-2.0
 
 base: core24
@@ -12,6 +15,10 @@ base: core24
 platforms:
   amd64:
   arm64:
+
+plugs:
+  shared-memory:
+    private: true
 
 package-repositories:
   - type: apt
@@ -124,7 +131,7 @@ apps:
 
   camera-detect-stream:
     daemon: simple
-    install-mode: disable
+    install-mode: enable
     environment:
       DATA_DIR: $SNAP
       SNAPCRAFT_PRELOAD_REDIRECT_ONLY_SHM: 1


### PR DESCRIPTION
One can rather use the [private shared memory interface](https://ubuntu.com/robotics/docs/ros-2-shared-memory-in-snaps#private-shared-memory-interface) to allow this.

```
plugs:
  shared-memory:
    private: true
```