### PR TITLE
Various corrections to Ubuntu Core image creation guide

### DIFF
--- a/ubuntu-core-image/README.md
+++ b/ubuntu-core-image/README.md
@@ -10,11 +10,16 @@ If the webcam is not mounted at `/dev/video0`, the path can be changed by settin
 
 ## Build the gadget snap
 
+Checkout the pi-gadget submodule:
+```
+git submodule update --init
+```
+
 Apply these changes to [gadget.yaml](pi-gadget/gadget.yaml):
 
 - Add the contents of [additions-to-gadget.yaml](additions-to-gadget.yaml) to the end.
 - ~~Around line number 10, change the seed partition size from `1200M` to `1500M`.~~
-- If you want to preconfigure WiFI, change the SSID and password.
+- If you want to pre-configure WiFI, uncomment the network config and set the SSID and password.
 - Add your Landscape account name if you want the device to automatically register as a pending device.
 
 In [Makefile](pi-gadget/Makefile) on line 150 change `fkms` to `kms`.
@@ -73,7 +78,7 @@ Accept the device onto your Landscape.
 Wait until the computer info shows and then go to the **Snaps** tab.
 Here you can click on **Install snaps**.
 Enter snap name `ubuntu-frame` and `24/stable` for _tracking channnel_.
-Clicvk **+** and also add `wpe-webkit-mir-kiosk` and `22/candidate`.
+Click **+** and also add `wpe-webkit-mir-kiosk` and `22/candidate`.
 Click **install**.
 
 ![install snap](../media/landscape-install.png)
@@ -96,5 +101,5 @@ This URL can be changed by setting snap options via a script on Landscape.
 An example script to do this can be found [here](https://github.com/canonical/landscape-scripts/blob/main/core/snaps/update-snap-config.py).
 
 ## Limitations
-- After a reboot, Mir Kiosk may fails to show the web view in case the web server hasn't fully started. In this case, it is necessary to restart the Mir Kiosk snap.
+- After a reboot, the Web Kiosk fails to show the web page in case the web server hasn't fully started. In this case, it is necessary to restart the `wpe-webkit-mir-kiosk` snap.
 - The USB camera should be connected before boot. Otherwise, after connecting the tf-lite application and Mir Kiosk should be restarted in the mentioned order.

--- a/ubuntu-core-image/README.md
+++ b/ubuntu-core-image/README.md
@@ -39,8 +39,9 @@ Including this in the model doesn't currently work, but can be installed after t
 - `wpe-webkit-mir-kiosk`
 
 Update the model:
-- Add the developer
+- Add the developer ID
 - Add the timestamp
+- Set `console-conf`'s `presence` to `required` if you need a user and SSH access for debugging
 
 Sign the model:
 

--- a/ubuntu-core-image/README.md
+++ b/ubuntu-core-image/README.md
@@ -87,7 +87,7 @@ This is equivalent to running the following on the device:
 ```
 sudo snap install ubuntu-frame --channel=24/stable
 sudo snap install wpe-webkit-mir-kiosk --channel=22/candidate
-```sudo
+```
 
 The installation command will take some time to be delivered to the device, and then executed.
 The result will be shown on Landscape.
@@ -96,10 +96,10 @@ If the installation was successful, you should see the annotated camera feed bei
 
 ![local monitor](../media/loca-monitor-frame.jpg)
 
-The URL that is served by the `wpe-webkit-mir-kiosk` is set to the `tf-ubuntu-frame-example`'s web server by default, in the [gadget.yaml](additions-to-gadget.yaml).
+By default, `wpe-webkit-mir-kiosk` opens the URL of the `tf-ubuntu-frame-example`'s web server. This is set in the [gadget.yaml](additions-to-gadget.yaml).
 This URL can be changed by setting snap options via a script on Landscape.
 An example script to do this can be found [here](https://github.com/canonical/landscape-scripts/blob/main/core/snaps/update-snap-config.py).
 
 ## Limitations
 - After a reboot, the Web Kiosk fails to show the web page in case the web server hasn't fully started. In this case, it is necessary to restart the `wpe-webkit-mir-kiosk` snap.
-- The USB camera should be connected before boot. Otherwise, after connecting the tf-lite application and Mir Kiosk should be restarted in the mentioned order.
+- The USB camera should be connected before boot. If the camera is connected after boot, `tf-ubuntu-frame-example` should be restarted after connecting the camera, followed by restarting `wpe-webkit-mir-kiosk`.

--- a/ubuntu-core-image/README.md
+++ b/ubuntu-core-image/README.md
@@ -38,6 +38,10 @@ Including this in the model doesn't currently work, but can be installed after t
 - `mesa-2404`
 - `wpe-webkit-mir-kiosk`
 
+Update the model:
+- Add the developer
+- Add the timestamp
+
 Sign the model:
 
 ```
@@ -47,7 +51,7 @@ snap sign -k my-model-key model.json > model.model
 Build the image:
 
 ```
-ubuntu-image snap --snap pi-gadget/pi_24-1_arm64.snap --snap ../ubuntu-frame/tf-custom-examples_0.0.2_arm64.snap --validation=enforce model.model
+ubuntu-image snap --snap pi-gadget/pi_24-1_arm64.snap --validation=enforce model.model
 ```
 
 ## Booting the Pi
@@ -73,6 +77,12 @@ Click **install**.
 
 ![install snap](../media/landscape-install.png)
 
+This is equivalent to running the following on the device:
+```
+sudo snap install ubuntu-frame --channel=24/stable
+sudo snap install wpe-webkit-mir-kiosk --channel=22/candidate
+```sudo
+
 The installation command will take some time to be delivered to the device, and then executed.
 The result will be shown on Landscape.
 
@@ -80,6 +90,10 @@ If the installation was successful, you should see the annotated camera feed bei
 
 ![local monitor](../media/loca-monitor-frame.jpg)
 
-The URL that is displayed by the `wpe-webkit-mir-kiosk` is set to be the `tf-ubuntu-frame-example` endpoint by default, in the [gadget.yaml](additions-to-gadget.yaml).
+The URL that is served by the `wpe-webkit-mir-kiosk` is set to the `tf-ubuntu-frame-example`'s web server by default, in the [gadget.yaml](additions-to-gadget.yaml).
 This URL can be changed by setting snap options via a script on Landscape.
 An example script to do this can be found [here](https://github.com/canonical/landscape-scripts/blob/main/core/snaps/update-snap-config.py).
+
+## Limitations
+- After a reboot, Mir Kiosk may fails to show the web view in case the web server hasn't fully started. In this case, it is necessary to restart the Mir Kiosk snap.
+- The USB camera should be connected before boot. Otherwise, after connecting the tf-lite application and Mir Kiosk should be restarted in the mentioned order.

--- a/ubuntu-core-image/additions-to-gadget.yaml
+++ b/ubuntu-core-image/additions-to-gadget.yaml
@@ -21,20 +21,15 @@ defaults:
       wait-for-serial-as: true
 
   system:
-    # Disable console-conf so that we do not have an interactive installer at first bootup
-    service:
-      console-conf:
-        disable: true
-
     # Add this if you want to preconfigure wifi credentials
-    system:
-      network:
-        netplan:
-          network:
-            version: 2
-            wifis:
-              wlan0:
-                dhcp4: true
-                access-points:
-                  "my-wifi-ssid":
-                    password: "my-wifi-password"
+    # system:
+    #   network:
+    #     netplan:
+    #       network:
+    #         version: 2
+    #         wifis:
+    #           wlan0:
+    #             dhcp4: true
+    #             access-points:
+    #               "my-wifi-ssid":
+    #                 password: "my-wifi-password"

--- a/ubuntu-core-image/additions-to-gadget.yaml
+++ b/ubuntu-core-image/additions-to-gadget.yaml
@@ -1,5 +1,6 @@
 connections:
-   -  plug: XXQ5289gHOZX3I7j6sqWLX4yAst4pNAQ:camera
+  # tf-ubuntu-frame-example
+  - plug: XXQ5289gHOZX3I7j6sqWLX4yAst4pNAQ:camera
 
 defaults:
   # Ubuntu frame
@@ -20,7 +21,7 @@ defaults:
       computer-title-pattern: ${model}-${serial:0:8}
       wait-for-serial-as: true
 
-  # Add this if you want to pre-configure wifi credentials
+  # Uncomment the following if you want to pre-configure wifi credentials
   # system:
   #   system:
   #     network:

--- a/ubuntu-core-image/additions-to-gadget.yaml
+++ b/ubuntu-core-image/additions-to-gadget.yaml
@@ -13,23 +13,23 @@ defaults:
   # Preconfigure Landscape Client
   ffnH0sJpX3NFAclH777M8BdXIWpo93af:
     landscape-url: https://landscape.canonical.com
-    account-name: "<REDACTED>"
+    account-name: "<account-name>"
     registration-key: ""
     auto-register:
       enabled: true
       computer-title-pattern: ${model}-${serial:0:8}
       wait-for-serial-as: true
 
-  system:
-    # Add this if you want to preconfigure wifi credentials
-    # system:
-    #   network:
-    #     netplan:
-    #       network:
-    #         version: 2
-    #         wifis:
-    #           wlan0:
-    #             dhcp4: true
-    #             access-points:
-    #               "my-wifi-ssid":
-    #                 password: "my-wifi-password"
+  # Add this if you want to pre-configure wifi credentials
+  # system:
+  #   system:
+  #     network:
+  #       netplan:
+  #         network:
+  #           version: 2
+  #           wifis:
+  #             wlan0:
+  #               dhcp4: true
+  #               access-points:
+  #                 "<wifi-ssid>":
+  #                   password: "<wifi-password>"

--- a/ubuntu-core-image/model.json
+++ b/ubuntu-core-image/model.json
@@ -3,9 +3,9 @@
     "series": "16",
     "model": "uc24-pi-arm64-tflite",
     "architecture": "arm64",
-    "authority-id": "5LfALSq3Z4FRd0bInQ9gtqN2EKOsvh7M",
-    "brand-id": "5LfALSq3Z4FRd0bInQ9gtqN2EKOsvh7M",
-    "timestamp": "2024-08-20T12:20:00+00:00",
+    "authority-id": "<developer-id>",
+    "brand-id": "<developer-id>",
+    "timestamp": "<timestamp>",
     "base": "core24",
     "grade": "dangerous",
     "serial-authority": [


### PR DESCRIPTION
Corrections to [#21](https://github.com/canonical/tf-lite-examples-snap/pull/21):
- Remove unneeded console conf disabling logic
- Add pi-gadget submodule
- Add limitations to README
- Update instructions
- Remove user-specific info from model assertion
- etc